### PR TITLE
devhub-tmp-cnu-codefix-uploader-go to 0.0.33

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: devhub-tmp-cnu-codefix-uploader-go
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.33
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote devhub-tmp-cnu-codefix-uploader-go to version 0.0.33